### PR TITLE
fix: Filters categories that contain the gender

### DIFF
--- a/libs/items/src/services/categories/list-category/service.ts
+++ b/libs/items/src/services/categories/list-category/service.ts
@@ -26,7 +26,7 @@ export async function listCategories(_args: ListCategoryRequest) {
           }
         : { enabled: true }),
 
-      ...(args?.gender ? { gender: { equals: [args.gender] } } : {}),
+      ...(args?.gender ? { gender: { has: args.gender } } : {}),
     },
   });
 


### PR DESCRIPTION
changed `equals args.gender` to `has args.gender`